### PR TITLE
fix the isExistant function

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -56,13 +56,10 @@ function setWidthHeight() {
 
 
 function isExistant(el) {
-  if (el !== undefined) {
-    if (el !== 0 || undefined || '' || null) {
-      return true;
-    }
+  if (el == null || el === '' || el === 0) {
+      return false;
   }
-  // else
-  return false;
+  return true;
 }
 
 // Numberformating


### PR DESCRIPTION
The original version return this results, and I think this is not what the author expected: 

```
isExistant()
false
isExistant(null)
true
isExistant(0)
false
isExistant('')
true
```

the new version will return `false` in every of the 4 cases.
